### PR TITLE
Refs Bug#391641 Keep data inputs of chat bot when create/update webhook fail

### DIFF
--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -41,7 +41,7 @@ class WebhookController extends Controller
     public function create()
     {
         $webhookStatuses = array_change_key_case(WebhookStatus::toArray());
-        $bots = Bot::pluck('id', 'name');
+        $bots = Bot::all();
 
         return view('webhooks.create', compact('webhookStatuses', 'bots'));
     }
@@ -79,7 +79,7 @@ class WebhookController extends Controller
         $this->authorize('update', $webhook);
         $payloads = $webhook->payloads()->get();
         $webhookStatuses = array_change_key_case(WebhookStatus::toArray());
-        $bots = Bot::pluck('id', 'name');
+        $bots = Bot::all();
 
         return view('webhooks.edit', compact('webhook', 'payloads', 'webhookStatuses', 'bots'));
     }

--- a/public/js/webhook.js
+++ b/public/js/webhook.js
@@ -1,6 +1,12 @@
 $(document).ready(function () {
     $('#cw_rooms').prop('disabled', true);
-    $('#cw_bots').change(function () {
+
+    load_room_name();
+    load_room_id();
+
+    function load_room_name() {
+        var room_name = document.getElementById("room_name").value;
+
         $.ajax({
             type: 'GET',
             url: '/rooms',
@@ -9,8 +15,14 @@ $(document).ready(function () {
                 'bot_id': $('#cw_bots').val()
             },
             success: function (data) {
+                $('#cw_rooms').find('option').remove().end();
                 $.each(data, function (index, value) {
-                    $('#cw_rooms').append("<option cw-room-id='" + value['room_id'] + "' value='" + value['name'] + "'>" + value['name'] + "</option>");
+                    if (value['name'] == room_name) {
+                        $('#cw_rooms').append("<option cw-room-id='" + value['room_id'] + "' value='" + value['name'] + "' selected='selected'>" + value['name'] + "</option>");
+                        $('#cw_rooms').select2('data', {id: value['name'], text: room_name});
+                    } else {
+                        $('#cw_rooms').append("<option cw-room-id='" + value['room_id'] + "' value='" + value['name'] + "'>" + value['name'] + "</option>");
+                    }
                 });
                 $('#cw_rooms').prop('disabled', false);
             },
@@ -20,6 +32,19 @@ $(document).ready(function () {
                 $('#cw_room_id').val('');
             }
         });
+    }
+
+    function load_room_id() {
+        var room_id = document.getElementById("room_id").value;
+
+        if (room_id) {
+          $('#cw_room_id').val(room_id);
+        }
+    }
+
+    $('#cw_bots').change(function () {
+        $('#cw_rooms').select2('data', {id: '', text: 'Choose one...'});
+        load_room_name();
     });
 
     $('#cw_rooms').change(function () {

--- a/resources/views/webhooks/create.blade.php
+++ b/resources/views/webhooks/create.blade.php
@@ -42,11 +42,11 @@
         </div>
         <div class="form-group">
             <div class="col-xs-4">
-                <label class="field-compulsory required" for="webhook_description">Chatwork bot</label>
+                <label class="field-compulsory required" for="webhook_bot_id">Chatwork bot</label>
                 <select id="cw_bots" name="bot_id" class="select-select2" style="width: 100%;" data-placeholder="Choose one..">
                     <option></option>
-                    @foreach($bots as $key => $value)
-                        <option value="{{ $value }}">{{ $key }}</option>
+                    @foreach($bots as $bot)
+                        <option value="{{ $bot->id }}" {{ old('bot_id') == $bot->id ? "selected" : "" }}>{{ $bot->name }}</option>
                     @endforeach
                 </select>
                 @error('bot_id')
@@ -56,9 +56,10 @@
                 @enderror
             </div>
             <div class="col-xs-4">
+                <input type="hidden" id="room_name" value="{{ old('room_name') }}">
                 <label class="field-compulsory required" for="cw_rooms">Chatwork room</label>
                 <select id="cw_rooms" name="room_name" class="select-select2" style="width: 100%;" data-placeholder="Choose one..">
-                <option></option>
+                    <option></option>
                 </select>
                 @error('room_name')
                     <div class="has-error">
@@ -68,6 +69,7 @@
             </div>
             <div class="col-xs-4">
                 <label class="field-compulsory required" for="cw_room_id">Chatwork room id</label>
+                <input type="hidden" id="room_id" value="{{ old('room_id') }}">
                 <input type="text" readonly id="cw_room_id" name="room_id" class="form-control">
                 @error('room_id')
                     <div class="has-error">

--- a/resources/views/webhooks/edit.blade.php
+++ b/resources/views/webhooks/edit.blade.php
@@ -4,147 +4,155 @@
 <link rel="stylesheet" href="{{ mix('/css/style.css') }}">
 <!-- Simple Editor Block -->
 <div class="block">
-	<!-- Simple Editor Title -->
-	<div class="block-title">
-		<h2><strong>Detail webhook</strong></h2>
-	</div>
-	<!-- END Simple Editor Title -->
-	<!-- Simple Editor Content -->
-	{{ Form::open(['url' => route('webhooks.update', ['webhook' => $webhook]), 'method' => 'PUT']) }}
-	<div class="form-group row">
-		<div class="col-xs-12">
-			<button type="submit" class="btn btn-sm btn-primary float-right"><i class="fa fa-check"></i> Save</button>
-			<a class="btn btn-sm btn-default float-right" href="{{ route('webhooks.index') }}"><i class="fa fa-times"></i> Cancel</a>
-		</div>
-		<div class="col-xs-8">
-			<label class="field-compulsory required" for="webhook_name">Webhook name</label>
-			<input type="text" id="webhook_name" name="name" class="form-control" value="{{  $webhook->name }}">
-			@error('name')
-			<div class="has-error">
-				<span class="help-block">{{ $message }}</span>
-			</div>
-			@enderror
-		</div>
-		<div class="col-xs-4">
-			<label class="field-compulsory required" for="webhook_status">Status</label>
-			<select id="webhook_status" name="status" class="form-control">
-				@foreach($webhookStatuses as $key => $value)
-				<option value="{{ $value }}" {{ $webhook->status == $value ? "selected" : "" }}>{{ $key }}</option>
-				@endforeach
-			</select>
-		</div>
-		<div class="col-xs-12">
-			<label class="field-compulsory">Token</label>
-			<input type="text" class="form-control" value="{{ $webhook->token }}" readonly>
-		</div>
-		<div class="col-xs-12">
-			<label class="field-compulsory required" for="webhook_description">Description</label>
-			<textarea class="form-control" rows="5" name="description" id="webhook_description">{{ $webhook->description }}</textarea>
-			@error('description')
-			<div class="has-error">
-				<span class="help-block">{{ $message }}</span>
-			</div>
-			@enderror
-		</div>
-	</div>
-	<div class="block">
-		<div class="form-group row">
-			<div class="col-xs-4">
-				<input type="hidden" name="id" value="{{ $webhook->id }}">
-				<label class="field-compulsory required">Chatwork bot</label>
-				<select id="bot_id" name="bot_id" class="form-control">
-					@foreach($bots as $key => $value)
-					<option value="{{ $value }}" {{ $webhook->bot()->first()->name == $key ? "selected" : "" }}>{{ $key }}</option>
-					@endforeach
-				</select>
-			</div>
-			<div class="col-xs-4">
-				<label class="field-compulsory required" for="cw_rooms">Chatwork room</label>
-				<select id="room_name" name="room_name" class="form-control">
-					<option selected value="{{ $webhook->room_name }}">{{ $webhook->room_name }}</option>
-				</select>
-				@error('room_name')
-				<div class="has-error">
-					<span class="help-block">{{ $message }}</span>
-				</div>
-				@enderror
-			</div>
-			<div class="col-xs-4">
-				<label class="field-compulsory required" for="cw_room_id">Chatwork room id</label>
-				<input type="text" readonly id="cw_room_id" name="room_id" class="form-control" value="{{ $webhook->room_id }}">
-				@error('room_id')
-				<div class="has-error">
-					<span class="help-block">{{ $message }}</span>
-				</div>
-				@enderror
-			</div>
-		</div>
-	</div>
-	{{ Form::close() }}
-	<div class="block payload-content">
-		<div class="form-group row">
-			<div class="col-xs-12">
-				<a class="btn btn-sm btn-primary float-right" href="{{ route('webhooks.payloads.create', $webhook->id) }}"><i class="fa fa-plus-circle"></i> Create</a>
-			</div>
-			<div class="col-xs-12">
-				<div class="col-xs-5">
-					<label class="field-compulsory" for="cw_room_id">Payload content</label>
-				</div>
-				<div class="col-xs-5">
-					<label class="field-compulsory" for="cw_room_id">Payload condition</label>
-				</div>
-				<div class="col-xs-2">
-					<label class="field-compulsory" for="cw_room_id">&nbsp &nbsp Action</label>
-				</div>
-			</div>
-			@include('webhooks.delete_confirm_modal')
-			@foreach($payloads as $key => $payload)
-			<div class="row">
-				<div class="col-xs-5">
-					<div class="panel panel-default">
-						<div class="panel-heading">
-							<h4 class="panel-title">{{ $payload->content }}</h4>
-						</div>
-					</div>
-				</div>
-				<div class="col-xs-5">
-					<div class="panel panel-default">
-							@if($payload->conditions->isEmpty())
-								<div class="panel-heading">
-									<h4 class="panel-title">No conditions</h4>
-								</div>
-							@else
-								@foreach($payload->conditions as $key => $condition)
-									<div class="panel-heading">
-										<h4 class="panel-title">{{$condition->field}} {{$condition->operator}} {{$condition->value}}</h4>
-									</div>
-								@endforeach
-							@endif
-					</div>
-				</div>
-				<div class="col-xs-2">
-					<a class="btn btn-sm btn-default" href="{{ route('webhooks.payloads.edit', ['webhook' => $webhook, 'payload' => $payload]) }} ">
-						<i class="fa fa-pencil"></i> Edit
-					</a>&nbsp
+    <!-- Simple Editor Title -->
+    <div class="block-title">
+        <h2><strong>Detail webhook</strong></h2>
+    </div>
+    <!-- END Simple Editor Title -->
+    <!-- Simple Editor Content -->
+    {{ Form::open(['url' => route('webhooks.update', ['webhook' => $webhook]), 'method' => 'PUT']) }}
+    <div class="form-group row">
+        <div class="col-xs-12">
+            <button type="submit" class="btn btn-sm btn-primary float-right"><i class="fa fa-check"></i> Save</button>
+            <a class="btn btn-sm btn-default float-right" href="{{ route('webhooks.index') }}"><i class="fa fa-times"></i> Cancel</a>
+        </div>
+        <div class="col-xs-8">
+            <label class="field-compulsory required" for="webhook_name">Webhook name</label>
+            <input type="text" id="webhook_name" name="name" class="form-control" value="{{  $webhook->name }}">
+            @error('name')
+            <div class="has-error">
+                <span class="help-block">{{ $message }}</span>
+            </div>
+            @enderror
+        </div>
+        <div class="col-xs-4">
+            <label class="field-compulsory required" for="webhook_status">Status</label>
+            <select id="webhook_status" name="status" class="form-control">
+                @foreach($webhookStatuses as $key => $value)
+                <option value="{{ $value }}" {{ $webhook->status == $value ? "selected" : "" }}>{{ $key }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div class="col-xs-12">
+            <label class="field-compulsory">Token</label>
+            <input type="text" class="form-control" value="{{ $webhook->token }}" readonly>
+        </div>
+        <div class="col-xs-12">
+            <label class="field-compulsory required" for="webhook_description">Description</label>
+            <textarea class="form-control" rows="5" name="description" id="webhook_description">{{ $webhook->description }}</textarea>
+            @error('description')
+            <div class="has-error">
+                <span class="help-block">{{ $message }}</span>
+            </div>
+            @enderror
+        </div>
+    </div>
+    <div class="block">
+        <div class="form-group row">
+            <div class="col-xs-4">
+                <input type="hidden" name="id" value="{{ $webhook->id }}">
+                <label class="field-compulsory required">Chatwork bot</label>
+                <select id="cw_bots" name="bot_id" class="select-select2" style="width: 100%;" data-placeholder="Choose one..">
+                    <option></option>
+                    @foreach($bots as $bot)
+                        <option value="{{ $bot->id }}" {{ $webhook->bot_id == $bot->id ? "selected" : "" }}>{{ $bot->name }}</option>
+                    @endforeach
+                </select>
+                @error('bot_id')
+                <div class="has-error">
+                    <span class="help-block">{{ $message }}</span>
+                </div>
+                @enderror
+            </div>
+            <div class="col-xs-4">
+                <input type="hidden" id="room_name" value="{{ $webhook->room_name }}">
+                <label class="field-compulsory required" for="cw_rooms">Chatwork room</label>
+                <select id="cw_rooms" name="room_name" class="select-select2" style="width: 100%;" data-placeholder="Choose one..">
+                    <option></option>
+                </select>
+                @error('room_name')
+                <div class="has-error">
+                    <span class="help-block">{{ $message }}</span>
+                </div>
+                @enderror
+            </div>
+            <div class="col-xs-4">
+                <label class="field-compulsory required" for="cw_room_id">Chatwork room id</label>
+                <input type="hidden" id="room_id" value="{{ $webhook->room_id }}">
+                <input type="text" readonly id="cw_room_id" name="room_id" class="form-control">
+                @error('room_id')
+                <div class="has-error">
+                    <span class="help-block">{{ $message }}</span>
+                </div>
+                @enderror
+            </div>
+        </div>
+    </div>
+    {{ Form::close() }}
+    <div class="block payload-content">
+        <div class="form-group row">
+            <div class="col-xs-12">
+                <a class="btn btn-sm btn-primary float-right" href="{{ route('webhooks.payloads.create', $webhook->id) }}"><i class="fa fa-plus-circle"></i> Create</a>
+            </div>
+            <div class="col-xs-12">
+                <div class="col-xs-5">
+                    <label class="field-compulsory" for="cw_room_id">Payload content</label>
+                </div>
+                <div class="col-xs-5">
+                    <label class="field-compulsory" for="cw_room_id">Payload condition</label>
+                </div>
+                <div class="col-xs-2">
+                    <label class="field-compulsory" for="cw_room_id">&nbsp &nbsp Action</label>
+                </div>
+            </div>
+            @include('webhooks.delete_confirm_modal')
+            @foreach($payloads as $key => $payload)
+            <div class="row">
+                <div class="col-xs-5">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h4 class="panel-title">{{ $payload->content }}</h4>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-xs-5">
+                    <div class="panel panel-default">
+                        @if($payload->conditions->isEmpty())
+                            <div class="panel-heading">
+                                <h4 class="panel-title">No conditions</h4>
+                            </div>
+                        @else
+                            @foreach($payload->conditions as $key => $condition)
+                            <div class="panel-heading">
+                                <h4 class="panel-title">{{$condition->field}} {{$condition->operator}} {{$condition->value}}</h4>
+                            </div>
+                            @endforeach
+                        @endif
+                    </div>
+                </div>
+		            <div class="col-xs-2">
+		                <a class="btn btn-sm btn-default" href="{{ route('webhooks.payloads.edit', ['webhook' => $webhook, 'payload' => $payload]) }} ">
+		                    <i class="fa fa-pencil"></i> Edit
+		                </a>&nbsp
 
-					{{ Form::open([
-							'method' => 'DELETE',
-							'route' => ['webhooks.payloads.destroy', 'webhook' => $webhook, 'payload' => $payload],
-							'style' => 'display:inline',
-							'class' => 'form-delete'
-					]) }}
-							{{ Form::button('<i class="fa fa-trash-o"> Delete</i>' , [
-											'type' => 'DELETE',
-											'class' => 'btn btn-sm btn-danger delete-btn',
-											'title' => 'Delete'
-							]) }}
-					{{ Form::close() }}
-				</div>
-			</div>
-			@endforeach
-		</div>
-	</div>
-	<!-- END Simple Editor Content -->
+		                {{ Form::open([
+		                    'method' => 'DELETE',
+		                    'route' => ['webhooks.payloads.destroy', 'webhook' => $webhook, 'payload' => $payload],
+		                    'style' => 'display:inline',
+		                    'class' => 'form-delete'
+		                ]) }}
+		                    {{ Form::button('<i class="fa fa-trash-o"> Delete</i>' , [
+                            'type' => 'DELETE',
+                            'class' => 'btn btn-sm btn-danger delete-btn',
+                            'title' => 'Delete'
+		                    ]) }}
+		                {{ Form::close() }}
+		            </div>
+            </div>
+            @endforeach
+        </div>
+    </div>
+    <!-- END Simple Editor Content -->
 </div>
 
 @endsection


### PR DESCRIPTION
…

## Related Tickets

- [#391641](https://dev.sun-asterisk.com/issues/391641)

## What's this PR do ?

- [x] Keep data inputs of chat bot when create/update webhook fail

## Library
*(List package, library third party add new include version)*

- NA
## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note purpose/reason, solution, scope of influence into ticket

## ENV note

```
```

## Notes
*(Other notes)*
![Screenshot from 2019-12-09 15-28-16](https://user-images.githubusercontent.com/49390791/70419874-f9694b80-1a98-11ea-8be8-60ef7ed36832.png)
![Screenshot from 2019-12-09 18-14-26](https://user-images.githubusercontent.com/49390791/70431491-c3839180-1aaf-11ea-9486-10b7a2d12807.png)
