### PR TITLE
Refs Task#405741 Don't show bot key when create/update bot

### DIFF
--- a/app/Http/Controllers/BotController.php
+++ b/app/Http/Controllers/BotController.php
@@ -90,12 +90,17 @@ class BotController extends Controller
 
     public function edit(Bot $bot)
     {
+        unset($bot->bot_key);
+
         return view('bots.edit', compact('bot'));
     }
 
     public function update(BotUpdateRequest $request, Bot $bot)
     {
         $data = $request->except('_token');
+        if ($data['bot_key'] == '') {
+            $data['bot_key'] = $bot->bot_key;
+        }
 
         try {
             $bot = $this->botRepository->update($bot->id, $data);

--- a/app/Http/Requests/BotUpdateRequest.php
+++ b/app/Http/Requests/BotUpdateRequest.php
@@ -25,7 +25,7 @@ class BotUpdateRequest extends FormRequest
      */
     public function rules()
     {
-        return [
+        $rules = [
             'name' => [
                 'required',
                 'max:50',
@@ -33,14 +33,18 @@ class BotUpdateRequest extends FormRequest
                     return $query->where('user_id', \Auth::id());
                 }),
             ],
-            'bot_key' => [
-                'required',
+        ];
+
+        if ($this->bot_key != '') {
+            $rules['bot_key'] = [
                 'max:50',
                 Rule::unique('bots')->ignore($this->id)->where(function ($query) {
                     return $query->where('user_id', \Auth::id());
                 }),
-            ],
-        ];
+            ];
+        }
+
+        return $rules;
     }
 
     public function messages()
@@ -49,7 +53,6 @@ class BotUpdateRequest extends FormRequest
             'name.required' => 'Please enter name',
             'name.max' => 'Name is too long (maximum is 50 characters)',
             'name.unique' => 'This bot name has already been used by another bot',
-            'bot_key.required' => 'Please enter bot key',
             'bot_key.max' => 'Bot key is too long (maximum is 50 characters)',
             'bot_key.unique' => 'This bot key has already been used by another bot',
         ];

--- a/resources/views/bots/create.blade.php
+++ b/resources/views/bots/create.blade.php
@@ -35,7 +35,7 @@
         <div class="form-group row">
             <div class="col-xs-4">
                 <label class="field-compulsory required" for="bot_key">Bot Key</label>
-                <input type="text" id="bot_key" name="bot_key" class="form-control" value="{{ old('bot_key') }}" placeholder="Enter bot key">
+                <input type="password" id="bot_key" name="bot_key" class="form-control" value="{{ old('bot_key') }}" placeholder="Enter bot key">
                 @error('bot_key')
                     <div class="has-error">
                         <span class="help-block">{{ $message }}</span>

--- a/resources/views/bots/edit.blade.php
+++ b/resources/views/bots/edit.blade.php
@@ -35,8 +35,8 @@
         </div>
         <div class="form-group row">
             <div class="col-xs-4">
-                <label class="field-compulsory required" for="bot_key">Bot Key</label>
-                <input type="text" id="bot_key" name="bot_key" class="form-control" value="{{ $bot->bot_key }}" placeholder="Enter bot key">
+                <label class="field-compulsory" for="bot_key">Bot Key</label>
+                <input type="password" id="bot_key" name="bot_key" class="form-control" value="{{ $bot->bot_key }}" placeholder="Enter bot key if you want to change">
                 @error('bot_key')
                     <div class="has-error">
                         <span class="help-block">{{ $message }}</span>

--- a/tests/Feature/BotControllerTest.php
+++ b/tests/Feature/BotControllerTest.php
@@ -519,27 +519,6 @@ class BotControllerTest extends TestCase
     }
 
     /**
-     * test bot required bot_key
-     *
-     * @return void
-     */
-    public function testUpdateBotRequiredBotKey()
-    {
-        $user = factory(User::class)->create();
-        $bot = factory(Bot::class)->create(['name' => 'Created Bot', 'user_id' => $user->id]);
-        $params = [
-            'name' => 'asd',
-            'bot_key' => null,
-        ];
-
-        $this->actingAs($user);
-        $response = $this->put(route('bots.update', $bot->id), $params);
-        $response
-            ->assertStatus(302)
-            ->assertSessionHasErrors('bot_key');
-    }
-
-    /**
      * test bot unique bot_key with user
      *
      * @return void


### PR DESCRIPTION
## Related Tickets

- [#405741](https://dev.sun-asterisk.com/issues/405741)

## What's this PR do ?

- [x] Don't show bot key when create/update bot

## Library
*(List package, library third party add new include version)*

- Library: google-analysis.js

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note purpose/reason, solution, scope of influence into ticket

## ENV note

```
```

## Notes
*(Other notes)*
![Screenshot from 2019-12-24 11-23-17](https://user-images.githubusercontent.com/49390791/71397017-c1443a00-264e-11ea-9337-6a92650de664.png)
![Screenshot from 2019-12-24 11-23-42](https://user-images.githubusercontent.com/49390791/71397018-c1dcd080-264e-11ea-92f1-d8cdc64d7dc5.png)
