### PR TITLE
chore(testcase): make /tests folder comply with psr-4

### DIFF
--- a/tests/Feature/AdminMessageHistoryControllerTest.php
+++ b/tests/Feature/AdminMessageHistoryControllerTest.php
@@ -2,73 +2,73 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\MessageHistory;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
 use App\Repositories\Eloquents\MessageHistoryRepository;
 use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
+use Tests\TestCase;
 
-class AdminMessageHistoryController extends TestCase
+class AdminMessageHistoryControllerTest extends TestCase
 {
     use RefreshDatabase;
+
     /**
-    * test Feature admin remove message history successfully.
-    *
-    * @return void
-    */
-   public function testRemoveMessageHistoryFeature()
-   {
-       $messageHistory = factory(MessageHistory::class)->create(['message_content' => 'test remove message history']);
-       $user = factory(User::class)->create(['role' => 0]);
-       $payloadHistoryId = $messageHistory->payloadHistory->id;
-       $this->actingAs($user);
-       $response = $this->delete(route('admin.message.destroy', $messageHistory));
-       $this->assertDatabaseMissing('message_histories', [
-           'id' => $messageHistory->id,
-           'message_content' => 'test remove message history',
-           'deleted_at' => NULL,
+     * test Feature admin remove message history successfully.
+     *
+     * @return void
+     */
+    public function testRemoveMessageHistoryFeature()
+    {
+        $messageHistory = factory(MessageHistory::class)->create(['message_content' => 'test remove message history']);
+        $user = factory(User::class)->create(['role' => 0]);
+        $payloadHistoryId = $messageHistory->payloadHistory->id;
+        $this->actingAs($user);
+        $response = $this->delete(route('admin.message.destroy', $messageHistory));
+        $this->assertDatabaseMissing('message_histories', [
+            'id' => $messageHistory->id,
+            'message_content' => 'test remove message history',
+            'deleted_at' => null,
         ]);
-       $response->assertRedirect(route('admin.history.show', ['history' => $payloadHistoryId]));
-       $response->assertStatus(302);
-   }
+        $response->assertRedirect(route('admin.history.show', ['history' => $payloadHistoryId]));
+        $response->assertStatus(302);
+    }
 
    /**
     * test Feature remove message history fail.
     *
     * @return void
     */
-   public function testRemoveMessageHistoryFailFeature()
-   {
-       $messageHistory = factory(MessageHistory::class)->create(['message_content' => 'test remove message history fail']);
-       $user = factory(User::class)->create(['role' => 0]);
+    public function testRemoveMessageHistoryFailFeature()
+    {
+        $messageHistory = factory(MessageHistory::class)->create(['message_content' => 'test remove message history fail']);
+        $user = factory(User::class)->create(['role' => 0]);
 
-       $this->actingAs($user);
-       $response = $this->delete(route('admin.message.destroy', $messageHistory->id + 99));
-       $this->assertDatabaseHas('message_histories', ['message_content' => 'test remove message history fail']);
-       $response->assertStatus(404);
-   }
-
-   /**
-    * test Feature remove message history unauthorized
-    *
-    * @return void
-    */
-   public function testRemoveMessageHistoryUnauthorizedFeature()
-   {
-       $response = $this->delete(route('admin.message.destroy', 1));
-
-       $response->assertLocation('/');
-       $response->assertStatus(302);
-   }
+        $this->actingAs($user);
+        $response = $this->delete(route('admin.message.destroy', $messageHistory->id + 99));
+        $this->assertDatabaseHas('message_histories', ['message_content' => 'test remove message history fail']);
+        $response->assertStatus(404);
+    }
 
     /**
-    * test remove message history permission denied
-    *
-    * @return void
-    */
+     * test Feature remove message history unauthorized
+     *
+     * @return void
+     */
+    public function testRemoveMessageHistoryUnauthorizedFeature()
+    {
+        $response = $this->delete(route('admin.message.destroy', 1));
+
+        $response->assertLocation('/');
+        $response->assertStatus(302);
+    }
+
+    /**
+     * test remove message history permission denied
+     *
+     * @return void
+     */
     public function testRemoveMessageHistoryPermissionDenied()
     {
         $messageHistory = factory(MessageHistory::class)->create();

--- a/tests/Unit/Models/BotTest.php
+++ b/tests/Unit/Models/BotTest.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Tests\Feature\Models;
+namespace Tests\Unit\Models;
 
 use App\Models\Bot;
 use App\Models\User;
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class BotTest extends TestCase
 {
@@ -19,7 +18,7 @@ class BotTest extends TestCase
             'user_id',
             'name',
             'type',
-            'bot_key'
+            'bot_key',
         ];
         $model = new Bot();
 

--- a/tests/Unit/Models/MappingTest.php
+++ b/tests/Unit/Models/MappingTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Feature\Models;
+namespace Tests\Unit\Models;
 
 use App\Models\Mapping;
-use Tests\TestCase;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class MappingTest extends TestCase
 {
@@ -14,7 +14,10 @@ class MappingTest extends TestCase
     public function test_contains_valid_fillable_properties()
     {
         $fillable = [
-            'webhook_id', 'name', 'key', 'value'
+            'webhook_id',
+            'name',
+            'key',
+            'value',
         ];
         $model = new Mapping();
 

--- a/tests/Unit/Models/MessageHistoryTest.php
+++ b/tests/Unit/Models/MessageHistoryTest.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace Tests\Feature\Models;
+namespace Tests\Unit\Models;
 
+use App\Enums\MessageHistoryStatus;
 use App\Models\MessageHistory;
 use App\Models\PayloadHistory;
-use App\Models\Webhook;
 use App\Models\User;
-use Tests\TestCase;
+use App\Models\Webhook;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use App\Enums\MessageHistoryStatus;
+use Tests\TestCase;
 
 class MessageHistoryTest extends TestCase
 {
@@ -19,7 +18,10 @@ class MessageHistoryTest extends TestCase
     public function test_contains_valid_fillable_properties()
     {
         $fillable = [
-            'payload_history_id', 'message_content', 'status', 'log'
+            'payload_history_id',
+            'message_content',
+            'status',
+            'log',
         ];
         $model = new MessageHistory();
 

--- a/tests/Unit/Models/PayloadHistoryTest.php
+++ b/tests/Unit/Models/PayloadHistoryTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Tests\Feature\Models;
+namespace Tests\Unit\Models;
 
+use App\Enums\PayloadHistoryStatus;
 use App\Models\PayloadHistory;
-use App\Models\Webhook;
 use App\Models\User;
-use Tests\TestCase;
+use App\Models\Webhook;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use App\Enums\PayloadHistoryStatus;
+use Tests\TestCase;
 
 class PayloadHistoryTest extends TestCase
 {
@@ -18,7 +18,10 @@ class PayloadHistoryTest extends TestCase
     public function test_contains_valid_fillable_properties()
     {
         $fillable = [
-            'webhook_id', 'params', 'status', 'log'
+            'webhook_id',
+            'params',
+            'status',
+            'log',
         ];
         $model = new PayloadHistory();
 

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,15 +1,11 @@
 <?php
 
-namespace Tests\Feature\Models;
+namespace Tests\Unit\Models;
 
 use App\Models\User;
-use App\Models\Bot;
-use App\Models\Webhook;
-use App\Models\Template;
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class UserTest extends TestCase
 {
@@ -32,7 +28,6 @@ class UserTest extends TestCase
     public function testUserHasManyBots()
     {
         $user = factory(User::class)->create();
-        $bot = factory(Bot::class)->create(['user_id' => $user->id]);
 
         $this->assertInstanceOf(HasMany::class, $user->bots());
         $this->assertEquals('user_id', $user->bots()->getForeignKeyName());
@@ -41,7 +36,6 @@ class UserTest extends TestCase
     public function testUserHasManyWebhooks()
     {
         $user = factory(User::class)->create();
-        $webhook = factory(Webhook::class)->create(['user_id' => $user->id]);
 
         $this->assertInstanceOf(HasMany::class, $user->webhooks());
         $this->assertEquals('user_id', $user->webhooks()->getForeignKeyName());
@@ -65,8 +59,11 @@ class UserTest extends TestCase
         $perPage = config('paginate.perPage');
         $user = factory(User::class)->create();
         factory(User::class, 2)->create(['name' => 'abc']);
-        $searchParams['name'] = $user->name;
-        $searchParams['email'] = $user->email;
+
+        $searchParams = [
+            'name' => $user->name,
+            'email' => $user->email,
+        ];
 
         $result = User::search($searchParams, $perPage);
 

--- a/tests/Unit/Models/WebhookTest.php
+++ b/tests/Unit/Models/WebhookTest.php
@@ -1,19 +1,18 @@
 <?php
 
-namespace Tests\Feature\Models;
+namespace Tests\Unit\Models;
 
-use App\Models\User;
-use App\Models\Bot;
-use App\Models\Webhook;
-use App\Models\Payload;
-use App\Models\Mapping;
-use App\Models\PayloadHistory;
 use App\Enums\WebhookStatus;
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Bot;
+use App\Models\Mapping;
+use App\Models\Payload;
+use App\Models\PayloadHistory;
+use App\Models\User;
+use App\Models\Webhook;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class WebhookTest extends TestCase
 {
@@ -38,18 +37,18 @@ class WebhookTest extends TestCase
 
     public function testWebhookBeLongsToUser()
     {
-        $user = factory(User::class)->create(); 
-        $webhook = factory(Webhook::class)->create(['user_id' => $user->id]); 
-        
+        $user = factory(User::class)->create();
+        $webhook = factory(Webhook::class)->create(['user_id' => $user->id]);
+
         $this->assertEquals('user_id', $webhook->user()->getForeignKeyName());
         $this->assertInstanceOf(BelongsTo::class, $webhook->user());
     }
 
     public function testWebhookBeLongsToBot()
     {
-        $bot = factory(Bot::class)->create(); 
-        $webhook = factory(Webhook::class)->create(['bot_id' => $bot->id]); 
-        
+        $bot = factory(Bot::class)->create();
+        $webhook = factory(Webhook::class)->create(['bot_id' => $bot->id]);
+
         $this->assertEquals('bot_id', $webhook->bot()->getForeignKeyName());
         $this->assertInstanceOf(BelongsTo::class, $webhook->bot());
     }
@@ -57,8 +56,8 @@ class WebhookTest extends TestCase
     public function testWebhookHasManyPayloads()
     {
         $webhook = factory(Webhook::class)->create();
-        $payload = factory(Payload::class)->create(['webhook_id' => $webhook->id]); 
-       
+        $payload = factory(Payload::class)->create(['webhook_id' => $webhook->id]);
+
         $this->assertInstanceOf(HasMany::class, $webhook->payloads());
         $this->assertEquals('webhook_id', $webhook->payloads()->getForeignKeyName());
     }
@@ -67,7 +66,7 @@ class WebhookTest extends TestCase
     {
         $webhook = factory(Webhook::class)->create();
         $mapping = factory(Mapping::class)->create(['webhook_id' => $webhook->id]);
-       
+
         $this->assertInstanceOf(HasMany::class, $webhook->mappings());
         $this->assertEquals('webhook_id', $webhook->mappings()->getForeignKeyName());
     }
@@ -76,7 +75,7 @@ class WebhookTest extends TestCase
     {
         $webhook = factory(Webhook::class)->create();
         $payloadHistory = factory(PayloadHistory::class)->create(['webhook_id' => $webhook->id]);
-       
+
         $this->assertInstanceOf(HasMany::class, $webhook->payloadHistories());
         $this->assertEquals('webhook_id', $webhook->payloadHistories()->getForeignKeyName());
     }


### PR DESCRIPTION
## What does this PR do

1. `/tests` folder complies with PSR-4 autoloading standard.
```
Class Tests\Feature\Models\WebhookTest located in ./tests/Unit/Models/WebhookTest.php
Class Tests\Feature\Models\MessageHistoryTest located in ./tests/Unit/Models/MessageHistoryTest.php
Class Tests\Feature\Models\BotTest located in ./tests/Unit/Models/BotTest.php
Class Tests\Feature\Models\UserTest located in ./tests/Unit/Models/UserTest.php
Class Tests\Feature\Models\MappingTest located in ./tests/Unit/Models/MappingTest.php
Class Tests\Feature\Models\PayloadHistoryTest located in ./tests/Unit/Models/PayloadHistoryTest.php
Class Tests\Feature\AdminMessageHistoryController located in ./tests/Feature/AdminMessageHistoryControllerTest.php
Class Tests\Feature\AdminPayloadHistoryController located in ./tests/Feature/AdminPayloadHistoryControllerTest.php
```
2. Fix phpcs error in these files.

## Checklist

- [ ] Tests added (if necessary, is mandatory for bug fixes)
- [x] Unit tests passed locally
- [x] phpcs/eslint passed locally
- [x] Commit messages are [semantic](https://www.conventionalcommits.org/)

